### PR TITLE
fix: remove style that causes hint label to disappear

### DIFF
--- a/src/app/app.component.styl
+++ b/src/app/app.component.styl
@@ -22,17 +22,6 @@ md-spinner.in-button-spinner
   margin: auto
 
 /**
- * md-hint fix
- */
-.mat-hint
-  position: absolute
-  font-size: 75%
-  bottom: -0.5em
-
-.mat-hint[align="end"]
-  right: 0
-
-/**
  * Fake tabs
  */
 


### PR DESCRIPTION
Looks like that piece of code is now deprecated!?

closes #471