### PR TITLE
Feat/perf home

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -15,7 +15,7 @@
   >
     CHAT
     <span
-      *ngIf="!ownSession && newMessages > 0 && currentTab !== 'chat'"
+      *ngIf="!isMeditating && newMessages > 0 && currentTab !== 'chat'"
       class="tab-indicator"
     >
       ({{newMessages}})
@@ -29,7 +29,7 @@
   >
     ASK
     <span
-      *ngIf="!ownSession && newQuestions > 0"
+      *ngIf="!isMeditating && newQuestions > 0"
       class="tab-indicator"
     >
       ({{newQuestions}})
@@ -41,20 +41,23 @@
   class="flexbox-parent"
   [class.hidden]="!isCurrentTab('meditation')"
   *ngIf="activated.indexOf('meditation') > -1"
+  (loadingFinished)="afterLoadedComponent()"
 ></meditation>
 
 <message
-  [class.hidden]="!isCurrentTab('chat') || ownSession"
+  [class.hidden]="!isCurrentTab('chat') || isMeditating"
   class="flexbox-parent"
   *ngIf="activated.indexOf('chat') > -1"
+  (loadingFinished)="afterLoadedComponent()"
 ></message>
 
 <question
-  [class.hidden]="!isCurrentTab('ask') || ownSession"
-  *ngIf="activated.indexOf('ask') > -1"
   class="flexbox-parent"
+  [class.hidden]="!isCurrentTab('ask') || isMeditating"
+  *ngIf="activated.indexOf('ask') > -1"
+  (loadingFinished)="afterLoadedComponent()"
 ></question>
 
-<div *ngIf="ownSession && !isCurrentTab('meditation')" class="disabled-message">
+<div *ngIf="isMeditating && !isCurrentTab('meditation')" class="disabled-message">
   <h3>This page is disabled during meditation.</h3>
 </div>

--- a/src/app/online/online.component.html
+++ b/src/app/online/online.component.html
@@ -1,6 +1,6 @@
 <div class="badge" *ngIf="!detailed">
   <button md-icon-button [routerLink]="['online']">
-    <md-icon>group</md-icon> <span>{{ onlineUsers.length }}</span>
+    <md-icon>group</md-icon> <span>{{ onlineCounter }}</span>
   </button>
 </div>
 

--- a/src/app/online/online.component.ts
+++ b/src/app/online/online.component.ts
@@ -12,7 +12,7 @@ import { UserService } from '../user';
 })
 export class OnlineComponent implements OnChanges, OnDestroy {
 
-  @Input() detailed: boolean = true;
+  @Input() detailed = true;
 
   socketSubscription: Subscription;
   onlineCounter = 0;

--- a/src/app/online/online.component.ts
+++ b/src/app/online/online.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Injectable, forwardRef, OnDestroy } from '@angular/core';
+import { Component, Input, Injectable, forwardRef, OnChanges, OnDestroy } from '@angular/core';
 import { Observable, Subscription } from 'rxjs/Rx';
 import { UserService } from '../user';
 
@@ -10,37 +10,48 @@ import { UserService } from '../user';
     './online.component.styl'
   ]
 })
-export class OnlineComponent implements OnDestroy {
+export class OnlineComponent implements OnChanges, OnDestroy {
 
-  @Input() detailed = true;
+  @Input() detailed: boolean = true;
+
   socketSubscription: Subscription;
-  pollingSubscription: Subscription;
+  onlineCounter = 0;
   onlineUsers: Array<any> = [];
 
-  constructor( public userService: UserService) {
-    // initially load online users
-    this.loadOnlineUsers();
+  constructor(public userService: UserService) {
+    // initially load online counter
+    this.userService.getOnlineCount()
+      .subscribe(res => this.onlineCounter = res);
 
     // intialize socket
-    this.socketSubscription = userService.getOnlineSocket().subscribe(() => {
-      this.loadOnlineUsers();
+    this.socketSubscription = userService.getOnlineSocket().subscribe(res => {
+      this.onlineCounter = this.onlineCounter + res >= 0
+        ? this.onlineCounter + res
+        : this.onlineCounter;
+
+      if (this.onlineCounter > 0 && this.detailed) {
+        this.loadOnlineUsers();
+      }
     });
 
-    // initialize polling
-    this.pollingSubscription = Observable.interval(120000)
-      .switchMap(() => this.userService.getOnline())
-      .map(res => (<any>res).json())
-      .subscribe(res => this.onlineUsers = res);
+    if (this.detailed) {
+      this.loadOnlineUsers();
+    }
   }
 
   loadOnlineUsers() {
-    this.userService.getOnline()
+    this.userService.getOnlineUsers()
       .map(res => res.json())
       .subscribe(res => this.onlineUsers = res);
   }
 
+  ngOnChanges() {
+    if (this.detailed) {
+      this.loadOnlineUsers();
+    }
+  }
+
   ngOnDestroy() {
     this.socketSubscription.unsubscribe();
-    this.pollingSubscription.unsubscribe();
   }
 }

--- a/src/app/question/question.component.ts
+++ b/src/app/question/question.component.ts
@@ -2,9 +2,11 @@ import {
   Component,
   ViewChild,
   ElementRef,
+  EventEmitter,
   ApplicationRef,
   OnInit,
-  OnDestroy
+  OnDestroy,
+  Output
 } from '@angular/core';
 import { FormBuilder, FormGroup, FormControl } from '@angular/forms';
 import { QuestionService } from './question.service';
@@ -20,6 +22,8 @@ import { UserService } from '../user/user.service';
   ]
 })
 export class QuestionComponent implements OnInit, OnDestroy {
+
+  @Output() loadingFinished: EventEmitter<any> = new EventEmitter<any>();
 
   questions: Object[];
   answeredQuestions: Object[];
@@ -83,6 +87,9 @@ export class QuestionComponent implements OnInit, OnDestroy {
       .subscribe(data => {
         this.questions = data;
         this.loadedInitially = true;
+
+        // loaded priority content
+        this.loadingFinished.emit();
       });
   }
 

--- a/src/app/shared/websocket.service.ts
+++ b/src/app/shared/websocket.service.ts
@@ -37,4 +37,14 @@ export class WebsocketService {
       websocket.on('message', res => obs.next(res));
     });
   }
+
+  /**
+   * Disconnects socket
+   */
+  public disconnect(): void {
+    io(ApiConfig.url, {
+      transports: ['websocket'],
+      query: 'token=' + window.localStorage.getItem('id_token')
+    }).close();
+  }
 }

--- a/src/app/user/testing/fake-user.service.ts
+++ b/src/app/user/testing/fake-user.service.ts
@@ -170,7 +170,11 @@ export class FakeUserService {
     return TestHelper.noResponse();
   }
 
-  public getOnline() {
+  public getOnlineUsers() {
+    return TestHelper.noResponse();
+  }
+
+  public getOnlineCount() {
     return TestHelper.noResponse();
   }
 

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -178,7 +178,7 @@ export class UserService {
     this.http.post(
       this.url + '/auth/logout',
       ''
-    ).subscribe(() => {});
+    ).subscribe(null, () => this.wsService.disconnect());
   }
 
   /**
@@ -258,7 +258,16 @@ export class UserService {
     );
   }
 
-  public getOnline() {
+  public getOnlineCount() {
+    const websocket = this.wsService.getSocket();
+
+    websocket.emit('onlinecounter:get');
+    return Observable.create(obs => {
+      websocket.on('onlinecounter:get', res => obs.next(res));
+    });
+  }
+
+  public getOnlineUsers() {
     return this.authHttp.get(
       ApiConfig.url + '/api/user/online', {
         headers: new Headers({
@@ -272,7 +281,7 @@ export class UserService {
     const websocket = this.wsService.getSocket();
 
     return Observable.create(obs => {
-      websocket.on('user-online', res => obs.next(res));
+      websocket.on('onlinecounter:changed', res => obs.next(res));
     });
   }
 


### PR DESCRIPTION
- makes online counter more accurate based on socket events
- makes some client side performance improvements by preventing that the Meditation component loads always when entering any tab and loading the tab hint numbers only after the real content has loaded 

comes together with https://github.com/Sirimangalo/meditation-plus-server/pull/178